### PR TITLE
Update/Improve PERM estimate

### DIFF
--- a/perm.jl
+++ b/perm.jl
@@ -1,0 +1,49 @@
+import PathWeightSampling as PWS
+
+import Random
+using StaticArrays
+
+using Plots
+
+import LogExpFunctions: logaddexp, logsumexp
+
+rates = SA[50.0, 1.0, 1.0, 1.0]
+rstoich = SA[Pair{Int, Int}[], [1 => 1], [1 => 1], [2 => 1]]
+nstoich = SA[[1 => 1], [1 => -1], [2 => 1], [2 => -1]]
+reactions = PWS.ReactionSet(rates, rstoich, nstoich, [:S, :X])
+u0 = SA[50.0, 50.0]
+tspan = (0.0, 10.0)
+system = PWS.MarkovJumpSystem(
+    PWS.GillespieDirect(),
+    reactions,
+    u0,
+    tspan,
+    :S,
+    :X
+)
+
+conf = PWS.generate_configuration(system; rng=Random.Xoshiro(1))
+
+
+conditional = PWS.conditional_density(system, PWS.DirectMCEstimate(1), conf)
+
+trace = conf.trace
+traced_reactions = system.output_reactions
+trace = PWS.filter_trace(trace, traced_reactions)
+
+
+algorithm = PWS.PERM(1000, 0.1, conditional)
+marginalization_result = PWS.simulate(algorithm, trace, system; Particle=PWS.JumpSystem.MarkovParticle)
+
+heatmap(marginalization_result.logZ)
+heatmap(log.(marginalization_result.num_samples))
+
+begin
+log_marginal = PWS.log_marginal(marginalization_result)
+p = plot(0 .* log_marginal)
+for i=1:10
+    log_marginal2 = PWS.marginal_density(system, PWS.SMCEstimate(512), conf)
+    plot!(p, log_marginal2 - log_marginal)
+end
+p
+end

--- a/src/marginal_strategies/flatPERM.jl
+++ b/src/marginal_strategies/flatPERM.jl
@@ -18,40 +18,31 @@ Compute the marginal trajectory probability using flatPERM.
 struct PERM <: AbstractSimulationAlgorithm
     num_chains::Int
     alpha::Float64
-    conditional::Vector{Float64}
 end
 
 name(x::PERM) = "PERM"
 
 
 struct PERMResult <: SimulationResult
-    logZ::Matrix{Float64}
-    num_samples::Matrix{Int}
-    num_samples_eff::Matrix{Float64}
+    logZ::Vector{Float64}
+    tour_weights::Matrix{Float64}
+    num_samples::Vector{Int}
 end
 
-log_marginal(result::PERMResult) = logsumexp(result.logZ, dims=2)[:, 1]
+log_marginal(result::PERMResult) = result.logZ
 
 # This is the main routine to compute the marginal probability in flatPERM.
-function flatperm(alg::PERM, setup; Particle, inspect=identity)
+function perm(alg::PERM, setup; Particle, inspect=identity)
 
     # this determines the time-interfaces at which we enrich or prune
     dtimes = discrete_times(setup.ensemble)
-    log_conditional = alg.conditional
 
-    # Make energy bins
-    M = 50 # number of bins
-    ΔW = 1e-1
-    α = alg.alpha
-    calc_m(W, n) = clamp(round(Int, expm1(α * W / n) / α / ΔW) + M÷2, 1, M)
+    # ln Z[n] Accumulated weight per length n. This will be the log marginal probability ln P(x)
+    logZ = fill(-Inf, length(dtimes))
+    tour_weights = fill(-Inf, length(dtimes), alg.num_chains)
 
-    n_min_prune = 5  # skip pruning for first 3 steps
-
-    # ln Ẑ[n, m] estimated partition sum. This will be the log marginal probability ln P(x)
-    logZ = fill(-Inf, length(dtimes), M)
-
-    # H[n, m] number of visits
-    H = zeros(Int, length(dtimes), M)
+    # H[n] counts the number of times every length n has been visited
+    H = zeros(length(dtimes))
 
     stack = Tuple{Particle, Float64, Int}[]
     for S = 1:alg.num_chains
@@ -72,41 +63,38 @@ function flatperm(alg::PERM, setup; Particle, inspect=identity)
                 # update the weight of the configuration
                 # note that weight(p) returns the log-likelihood increment
                 logW += weight(p) 
-                m = calc_m(logW - log_conditional[n], n)
 
                 # --- Update estimators ---
-                logZ[n, m] = logaddexp(logW, logZ[n, m])
-                H[n, m] += 1
+                logZ[n] = logaddexp(logW, logZ[n])
+                tour_weights[n, S] = logaddexp(logW, tour_weights[n, S])
+                H[n] += 1
 
-                if n < n_min_prune
-                    n += 1
-                    # grow without pruning
-                    continue
-                end
-
-                # --- Compute ratio ---
-                if logZ[n, m] == -Inf
-                    r = 1
+                # --- Compute thresholds ---
+                if S < 100
+                    c_low = -Inf
+                    c_high = Inf
                 else
-                    r = exp(logW - logZ[n, m] + log(S))
+                    logz_n = logZ[n] - log(S)
+                    c_low = logz_n + log(0.3)
+                    c_high = logz_n + log(3)
                 end
 
                 n += 1 # we increased the size through propagation
 
                 # --- Enrichment ---
-                if r > 1
-                    k = floor(r + rand())   # stochastic rounding
+                if logW > c_high
+                    k = 2
                     logW -= log(k) # W <- W/k
 
                     for i = 2:k
                         push!(stack, (clone(p, setup), logW, n))
                     end
                 # --- Pruning ---
-                else
-                    if rand() > r
-                        break                      # prune
+                elseif logW < c_low
+                    if rand() < 0.5
+                        break # prune
                     else
-                        logW = log(r)               # rescale weight
+                        logW += log(2) # W <- 2*W
                     end
                 end
             end
@@ -120,14 +108,15 @@ function flatperm(alg::PERM, setup; Particle, inspect=identity)
     end
 
     logZ .-= log(alg.num_chains)
-    logZ[1, :] .= -log(M)
+    logZ[1] = 0.0
+    H[1] = alg.num_chains
 
-    PERMResult(logZ, H, zeros(length(dtimes), M))
+    PERMResult(logZ, tour_weights, H)
 end
 
 function simulate(algorithm::PERM, initial, system; rng=Random.default_rng(), kwargs...)
     setup = Setup(initial, system, rng)
-    flatperm(algorithm, setup; kwargs...)
+    perm(algorithm, setup; kwargs...)
 end
 
 end # module

--- a/test/algorithms/smc_estimate.jl
+++ b/test/algorithms/smc_estimate.jl
@@ -24,11 +24,14 @@ algs = [PWS.SMCEstimate(256), PWS.DirectMCEstimate(256), PWS.PERM(32)]
 result = Dict(map(algs) do alg
     num_samples = 24
     mi = Vector{Vector{Float64}}(undef, num_samples)
-    for i in eachindex(mi)
-        @time "Generate Sample $i/$num_samples with $(PWS.name(alg))" begin
-            cresult = PWS.conditional_density(system, alg, conf)
-            mresult = PWS.marginal_density(system, alg, conf)
-            mi[i] = cresult - mresult
+    @sync for i in eachindex(mi)
+        local_system = copy(system)
+        Threads.@spawn begin
+            @time "Generate Sample $i/$num_samples with $(PWS.name(alg))" begin
+                cresult = PWS.conditional_density(local_system, alg, conf)
+                mresult = PWS.marginal_density(local_system, alg, conf)
+                mi[i] = cresult - mresult
+            end
         end
     end
     PWS.name(alg) => reduce(hcat, mi)

--- a/test/integration/simple_system.jl
+++ b/test/integration/simple_system.jl
@@ -11,7 +11,7 @@ using Test
 using Statistics
 using DataFrames
 
-
+println("Test chemotaxis system")
 system = PWS.chemotaxis_system(n=3, n_clusters=800, duration=2.0, dt=0.1)
 dtimes = PWS.discrete_times(system)
 
@@ -23,7 +23,7 @@ conf = PWS.generate_configuration(system)
 
 algorithms = [PWS.DirectMCEstimate(128), PWS.SMCEstimate(128), PWS.PERM(16)]
 for algorithm in algorithms
-    mi = PWS.mutual_information(system, algorithm, num_samples=4, progress=false)
+    @time "using algorithm $(PWS.name(algorithm))" mi = PWS.mutual_information(system, algorithm, num_samples=4, threads=true, progress=false)
     @test length(mi.result.MutualInformation) == 4 * length(dtimes)
     @test mi.result.MutualInformation[mi.result.time .== 0] == [0, 0, 0, 0]
     for (i, g) in enumerate(groupby(mi.result, :time))


### PR DESCRIPTION
The Pruned-Enriched Rosenbluth method is an alternative marginalization method that potentially could work better in some cases than SMC. I am investigating in this pull request.

I changed the implementation of PERM from recursive to a loop for better performance. I also found a few correctness issues with this estimator that I fixed.